### PR TITLE
feat: add `Serie A Standings` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,15 +11,21 @@
         "Other"
     ],
     "activationEvents": [
-        "onCommand:vscode-juve.fixturesResults"
+        "onCommand:vscode-juve.fixtures-results",
+        "onCommand:vscode-juve.serie-a-standings"
     ],
     "main": "./out/extension.js",
     "contributes": {
         "commands": [
             {
-                "command": "vscode-juve.fixturesResults",
+                "command": "vscode-juve.fixtures-results",
                 "category": "Juventus",
                 "title": "Fixtures & Results"
+            },
+            {
+                "command": "vscode-juve.serie-a-standings",
+                "category": "Juventus",
+                "title": "Serie A Standings"
             }
         ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,23 @@
 import * as vscode from 'vscode';
 
 export function activate(context: vscode.ExtensionContext) {
-    let disposable = vscode.commands.registerCommand('vscode-juve.fixturesResults', () => {
-        vscode.env.openExternal(vscode.Uri.parse('https://www.juventus.com/en/teams/first-team-men/fixtures-results/'));
 
-    });
+    const disposables: vscode.Disposable[] = [];
 
-    context.subscriptions.push(disposable);
+    disposables.push(
+        vscode.commands.registerCommand('vscode-juve.fixtures-results', () => {
+            vscode.env.openExternal(vscode.Uri.parse('https://www.google.com/search?q=juventus+standings&oq=juventus+standings&aqs=chrome.0.0i20i263i512j0i512j0i20i263i512j0i512j0i10i512j0i22i30l2j69i60.3738j1j4&sourceid=chrome&ie=UTF-8#sie=t;/m/045xx;2;/m/03zv9;mt;fp;1;;;'));
+        })
+    );
+
+    disposables.push(
+        vscode.commands.registerCommand('vscode-juve.serie-a-standings', () => {
+            vscode.env.openExternal(vscode.Uri.parse('https://www.google.com/search?q=juventus+standings&oq=juventus+standings&aqs=chrome.0.0i20i263i512j0i512j0i20i263i512j0i512j0i10i512j0i22i30l2j69i60.3738j1j4&sourceid=chrome&ie=UTF-8#sie=t;/m/045xx;2;/m/03zv9;st;fp;1;;;'));
+        })
+    );
+
+
+    context.subscriptions.push(...disposables);
 }
 
 export function deactivate() { }


### PR DESCRIPTION
#### Description

The commit adds support for the `Serie A Standings` command which opens an external link to show Juventus standings.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>