### PR TITLE
feat: add `News` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     ],
     "activationEvents": [
         "onCommand:vscode-juve.fixtures-results",
-        "onCommand:vscode-juve.serie-a-standings"
+        "onCommand:vscode-juve.serie-a-standings",
+        "onCommand:vscode-juve.news"
     ],
     "main": "./out/extension.js",
     "contributes": {
@@ -26,6 +27,11 @@
                 "command": "vscode-juve.serie-a-standings",
                 "category": "Juventus",
                 "title": "Serie A Standings"
+            },
+            {
+                "command": "vscode-juve.news",
+                "category": "Juventus",
+                "title": "News"
             }
         ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,12 @@ export function activate(context: vscode.ExtensionContext) {
         })
     );
 
+    disposables.push(
+        vscode.commands.registerCommand('vscode-juve.news', () => {
+            vscode.env.openExternal(vscode.Uri.parse('https://www.google.com/search?q=juventus+matches&oq=juventus+matches&aqs=chrome..69i57j0i512l5j69i60j69i61.2874j1j7&sourceid=chrome&ie=UTF-8#sie=t;/m/045xx;2;/m/03zv9;nw;fp;1;;;'));
+        })
+    );
+
 
     context.subscriptions.push(...disposables);
 }


### PR DESCRIPTION
### Description

The commit adds the `News` command to open an external url for Juventus related news.

Signed-off-by: vince-fugnitto <vincent.fugnitto@ericsson.com>